### PR TITLE
add struct iovec definition for OpenBSD

### DIFF
--- a/deps/snappy/openbsd/snappy-stubs-public.h
+++ b/deps/snappy/openbsd/snappy-stubs-public.h
@@ -80,6 +80,15 @@ typedef std::string string;
   TypeName(const TypeName&);               \
   void operator=(const TypeName&)
 
+#if !1
+// Windows does not have an iovec type, yet the concept is universally useful.
+// It is simple to define it ourselves, so we put it inside our own namespace.
+struct iovec {
+	void* iov_base;
+	size_t iov_len;
+};
+#endif
+
 }  // namespace snappy
 
 #endif  // UTIL_SNAPPY_OPENSOURCE_SNAPPY_STUBS_PUBLIC_H_

--- a/deps/snappy/snappy-1.1.4/snappy.cc
+++ b/deps/snappy/snappy-1.1.4/snappy.cc
@@ -42,6 +42,11 @@
 
 namespace snappy {
 
+struct iovec {
+  void* iov_base;
+  size_t iov_len;
+};
+
 using internal::COPY_1_BYTE_OFFSET;
 using internal::COPY_2_BYTE_OFFSET;
 using internal::LITERAL;


### PR DESCRIPTION
Hi @qbit.  I needed to add struct iovec definition to snappy.cc to be able to compile it on OpenBSD 6.1.  My changes are nasty, I did not have more time to clean it up and look deeper in to the problem.  I wonder how it compiled on your device without these changes? (I'm qwerty and hptr on patchwork)